### PR TITLE
Display Items  - feat: Implement Item editing, deletion, and quantity reduction

### DIFF
--- a/app/src/main/java/com/android/example/compose_training/AppViewModelProvider.kt
+++ b/app/src/main/java/com/android/example/compose_training/AppViewModelProvider.kt
@@ -19,7 +19,8 @@ object AppViewModelProvider {
         // Initializer for ItemEditViewModel
         initializer {
             ItemEditViewModel(
-                this.createSavedStateHandle()
+                this.createSavedStateHandle(),
+                inventoryApplication().container.itemsRepository
             )
         }
         // Initializer for ItemEntryViewModel
@@ -32,13 +33,14 @@ object AppViewModelProvider {
         // Initializer for ItemDetailsViewModel
         initializer {
             ItemDetailsViewModel(
-                this.createSavedStateHandle()
+                this.createSavedStateHandle(),
+                inventoryApplication().container.itemsRepository
             )
         }
 
         // Initializer for HomeViewModel
         initializer {
-            HomeViewModel()
+            HomeViewModel(inventoryApplication().container.itemsRepository)
         }
     }
 }

--- a/app/src/main/java/com/android/example/compose_training/home/HomeViewModel.kt
+++ b/app/src/main/java/com/android/example/compose_training/home/HomeViewModel.kt
@@ -1,12 +1,38 @@
 package com.android.example.compose_training.home
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.android.example.compose_training.data.Item
+import com.android.example.compose_training.data.ItemsRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 /**
  * ViewModel to retrieve all items in the Room database.
  */
-class HomeViewModel : ViewModel() {
+class HomeViewModel(private val itemsRepository: ItemsRepository) : ViewModel() {
+    
+    /**
+     * Holds home ui state. The list of items are retrieved from [ItemsRepository] and mapped to
+     * [HomeUiState]
+     */
+    val homeUiState: StateFlow<HomeUiState> =
+        itemsRepository.getAllItemsStream().map { HomeUiState(it) }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
+                initialValue = HomeUiState()
+            )
+            
+    /**
+     * Deletes an item from the database
+     */
+    suspend fun deleteItem(item: Item) {
+        itemsRepository.deleteItem(item)
+    }
+    
     companion object {
         private const val TIMEOUT_MILLIS = 5_000L
     }

--- a/app/src/main/java/com/android/example/compose_training/item/ItemDetailsViewModel.kt
+++ b/app/src/main/java/com/android/example/compose_training/item/ItemDetailsViewModel.kt
@@ -2,15 +2,58 @@ package com.android.example.compose_training.item
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.example.compose_training.data.ItemsRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 /**
  * ViewModel to retrieve, update and delete an item from the [ItemsRepository]'s data source.
  */
 class ItemDetailsViewModel(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val itemsRepository: ItemsRepository
 ) : ViewModel() {
 
     private val itemId: Int = checkNotNull(savedStateHandle[ItemDetailsDestination.itemIdArg])
+
+    val uiState: StateFlow<ItemDetailsUiState> =
+        itemsRepository.getItemStream(itemId)
+            .filterNotNull()
+            .map {
+                ItemDetailsUiState(
+                    outOfStock = it.quantity <= 0,
+                    itemDetails = it.toItemDetails()
+                )
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(TIMEOUT_MILLIS),
+                initialValue = ItemDetailsUiState()
+            )
+
+    /**
+     * Reduces the item quantity by one and update the item in the data source
+     */
+    suspend fun reduceQuantityByOne() {
+        val item = itemsRepository.getItemStream(itemId)
+            .filterNotNull()
+            .first()
+        itemsRepository.updateItem(item.copy(quantity = item.quantity - 1))
+    }
+
+    /**
+     * Deletes the item from the data source
+     */
+    suspend fun deleteItem() {
+        val item = itemsRepository.getItemStream(itemId)
+            .filterNotNull()
+            .first()
+        itemsRepository.deleteItem(item)
+    }
 
     companion object {
         private const val TIMEOUT_MILLIS = 5_000L

--- a/app/src/main/java/com/android/example/compose_training/item/ItemEditScreen.kt
+++ b/app/src/main/java/com/android/example/compose_training/item/ItemEditScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
@@ -18,6 +19,7 @@ import com.android.example.compose_training.InventoryTopAppBar
 import com.android.example.compose_training.R
 import com.android.example.compose_training.navigation.NavigationDestination
 import com.android.example.compose_training.ui.theme.ComposetrainingTheme
+import kotlinx.coroutines.launch
 
 
 object ItemEditDestination : NavigationDestination {
@@ -35,6 +37,8 @@ fun ItemEditScreen(
     modifier: Modifier = Modifier,
     viewModel: ItemEditViewModel = viewModel(factory = AppViewModelProvider.Factory)
 ) {
+    val coroutineScope = rememberCoroutineScope()
+
     Scaffold(
         topBar = {
             InventoryTopAppBar(
@@ -47,8 +51,13 @@ fun ItemEditScreen(
     ) { innerPadding ->
         ItemEntryBody(
             itemUiState = viewModel.itemUiState,
-            onItemValueChange = { },
-            onSaveClick = { },
+            onItemValueChange = viewModel::updateUiState,
+            onSaveClick = {
+                coroutineScope.launch {
+                    viewModel.updateItem()
+                    navigateBack()
+                }
+            },
             modifier = Modifier
                 .padding(
                     start = innerPadding.calculateStartPadding(LocalLayoutDirection.current),

--- a/app/src/main/java/com/android/example/compose_training/item/ItemEditViewModel.kt
+++ b/app/src/main/java/com/android/example/compose_training/item/ItemEditViewModel.kt
@@ -5,12 +5,18 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.example.compose_training.data.ItemsRepository
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel to retrieve and update an item from the [ItemsRepository]'s data source.
  */
 class ItemEditViewModel(
     savedStateHandle: SavedStateHandle,
+    private val itemsRepository: ItemsRepository
 ) : ViewModel() {
 
     /**
@@ -21,9 +27,38 @@ class ItemEditViewModel(
 
     private val itemId: Int = checkNotNull(savedStateHandle[ItemEditDestination.itemIdArg])
 
+    init {
+        viewModelScope.launch {
+            itemUiState = itemsRepository.getItemStream(itemId)
+                .filterNotNull()
+                .first()
+                .toItemUiState(true)
+        }
+    }
+
+    /**
+     * Updates the [itemUiState] with the value provided in the argument. This method also triggers
+     * a validation for input values.
+     */
+    fun updateUiState(itemDetails: ItemDetails) {
+        itemUiState = ItemUiState(
+            itemDetails = itemDetails,
+            isEntryValid = validateInput(itemDetails)
+        )
+    }
+
     private fun validateInput(uiState: ItemDetails = itemUiState.itemDetails): Boolean {
         return with(uiState) {
             name.isNotBlank() && price.isNotBlank() && quantity.isNotBlank()
+        }
+    }
+
+    /**
+     * Updates an item in the [ItemsRepository]'s data source
+     */
+    suspend fun updateItem() {
+        if (validateInput(itemUiState.itemDetails)) {
+            itemsRepository.updateItem(itemUiState.itemDetails.toItem())
         }
     }
 }


### PR DESCRIPTION
This commit introduces the ability to edit, delete, and reduce the quantity of items. Key changes include:

-   **Item Editing:**
    -   Added functionality to the `ItemEditViewModel` to update an item.
    -   Implemented `updateUiState` and `updateItem` to handle item data validation and update actions.
    -   Updated `ItemEditScreen` to handle item edits using the new `ItemEditViewModel` features.
-   **Item Details:**
    - Updated the `ItemDetailsViewModel` to support updating item quantity and deleting an item from the database.
    - Implemented `reduceQuantityByOne()` and `deleteItem()` methods for handling item quantity reduction and item deletion.
    - Added a `StateFlow` called `uiState` to manage and represent the UI state of item details.
    - Added the ability to check if the item is out of stock.
    - Updated `ItemDetailsScreen` to sell an item using the new `ItemDetailsViewModel` features.
    - Updated `ItemDetailsScreen` to delete an item using the new `ItemDetailsViewModel` features.
    - Updated `ItemDetailsScreen` to show the delete confirmation dialog.
-   **Home Screen:**
    -   Implemented item deletion in `HomeViewModel` using `deleteItem` method.
    -   Updated `HomeScreen` to trigger item deletion from `HomeViewModel`.
    -   Added a confirmation dialog before deleting an item.
    -   Updated `InventoryList` to add a delete item button and delete confirmation dialog.
    - Added `homeUiState` as a `StateFlow` in `HomeViewModel` to manage the list of items.
    - Added the capability to display the `HomeBody` with an empty list.
- **ViewModelFactory:**
    - Updated `AppViewModelProvider` to provide instances of `HomeViewModel`, `ItemDetailsViewModel` and `ItemEditViewModel` with the new dependencies.